### PR TITLE
`kraft.cloud.yaml`: Add networking support

### DIFF
--- a/kraft.cloud.yaml
+++ b/kraft.cloud.yaml
@@ -18,7 +18,6 @@ targets:
       - CONFIG_LIBVFSCORE_ROOTFS_INITRD=y
       - CONFIG_LIBVFSCORE_ROOTFS="initrd"
       - CONFIG_VIRTIO_BUS=y
-      - CONFIG_VIRTIO_NET=n
 libraries:
   musl:
     version: stable


### PR DESCRIPTION
Add networking support to `kraft.cloud.yaml`, to enable full features of Python support (such as running the `http.server` module).

This will require a different way of running the Unikernel image. Use the following commands to run the `http.server` module:

```console
rm -fr fs0
mkdir fs0
tar -C fs0 -xf rootfs.tar.gz
sudo ~/kraftkit/dist/kraft net rm kraft0
sudo ~/kraftkit/dist/kraft net create -n 172.44.0.1/24 kraft0
sudo kraft run --log-type basic --log-level debug --kraftfile kraft.cloud.yaml --plat firecracker --network bridge:kraft0 --initrd ./fs0 -M 256M -a netdev.ipv4_addr=172.44.0.2 -a netdev.ipv4_gw_addr=172.44.0.1 -a netdev.ipv4_subnet_mask=255.255.255.0 -- "-m http.server 8080"
```

To run `helloworld.py`, use:

```console
rm -fr fs0
mkdir fs0
tar -C fs0 -xf rootfs.tar.gz
sudo ~/kraftkit/dist/kraft net rm kraft0
sudo ~/kraftkit/dist/kraft net create -n 172.44.0.1/24 kraft0
cp helloworld.py fs0/
sudo kraft run --log-type basic --log-level debug --kraftfile kraft.cloud.yaml --plat firecracker --network bridge:kraft0 --initrd ./fs0 -M 256M -- "helloworld.py"
```